### PR TITLE
feat(frontend): improve copying of issue template

### DIFF
--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -14,8 +14,8 @@ export const issueUrl = ( { id, gurmukhi, page, nameEnglish } ) => newGithubIssu
 | ID | ${id} |
 | Source | ${nameEnglish} |
 | Page | ${page} |
-| Line | \`\`\`${gurmukhi}\`\`\` |
-| Correction | \`\`\`THIS\`\`\` ≠ \`\`\`THAT\`\`\`  |
+| Line | ${gurmukhi} |
+| Correction | THIS ≠ THAT  |
 
 PROOF (EDITION)
 


### PR DESCRIPTION
triple clicking and copying a line in the issue template would also copy the hidden code tags. this interfered with simply copying a line from the issue template and searching for it in the database viewer or pull requests.