### PR TITLE
Clarify to user where they can click on the UI for Line View

### DIFF
--- a/frontend/src/components/LineView.css
+++ b/frontend/src/components/LineView.css
@@ -35,7 +35,7 @@
 .line-view .header h1 a:hover {
   cursor: pointer;
   outline: none;
-  background: #dccda2;
+  background: #A2CED8;
   border-bottom: 2px solid rgba(0,0,0,.1);
 }
 

--- a/frontend/src/components/LineView.css
+++ b/frontend/src/components/LineView.css
@@ -26,10 +26,17 @@
   color: #2D2026;
 }
 
+.line-view .header h1 a {
+  transition: all 0.125s ease-in-out;
+  border-radius: 0.136em;
+  border-bottom: 2px solid rgba(0,136,191,.4);
+}
+
 .line-view .header h1 a:hover {
   cursor: pointer;
   outline: none;
-  border-bottom: 2px solid rgba(0, 0, 0, 0.1);
+  background: #dccda2;
+  border-bottom: 2px solid rgba(0,0,0,.1);
 }
 
 .line-view .header .buttons {

--- a/frontend/src/components/TranslationBlock.css
+++ b/frontend/src/components/TranslationBlock.css
@@ -11,6 +11,12 @@
   font-family: 'Noto Sans';
   cursor: pointer;
   user-select: none;
+  margin: 0;
+  padding: 1em 0;
+}
+
+.translation-block .source-name:hover {
+  background: #dccda280;
 }
 
 .translation-block .blocks {


### PR DESCRIPTION
### Summary of PR
Made it more obvious to the user without randomly waving the mouse around to see what they can click on. I did not add a toggle indicator for the headers, but that could be done for further clarity to the user. The yellow color is taken from previous screens to indicate app interaction zones. Blue color is almost universally used for links on the web, so I used that for the external links.

Before on left (underline for word and no background for headers); PR on right:

![image](https://user-images.githubusercontent.com/14130567/91747133-aa65c800-eb8b-11ea-967c-be7be32f0c65.png)

### Time spent on PR
30 minutes

### Reviewers
@Harjot1Singh 