### PR TITLE
fix(backend): return correct line for line index

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -26,18 +26,19 @@ export const getSources = () => Shabads
  */
 export const getTranslationSources = () => TranslationSources.query().eager( 'language' )
 
+const getLinesOnPageBase = ( sourceId, page ) => Lines
+  .query()
+  .join( 'shabads', 'shabads.id', 'lines.shabad_id' )
+  .where( 'source_page', page )
+  .andWhere( 'shabads.source_id', sourceId )
+  .orderBy( 'order_id' )
+
 /**
  * Get all the lines on a page for a source.
  * @param {number} sourceId The ID of the source to use.
  * @param {number} page The page in the source to retrieve all lines from.
  */
-export const getLinesOnPage = ( sourceId, page ) => Lines
-  .query()
-  .join( 'shabads', 'shabads.id', 'lines.shabad_id' )
-  .eager( 'shabad.[section, subsection]' )
-  .where( 'source_page', page )
-  .andWhere( 'shabads.source_id', sourceId )
-  .orderBy( 'order_id' )
+export const getLinesOnPage = ( sourceId, page ) => getLinesOnPageBase( sourceId, page ).eager( 'shabad.[section, subsection]' )
 
 /**
  * Gets a line for the source page.
@@ -45,14 +46,14 @@ export const getLinesOnPage = ( sourceId, page ) => Lines
  * @param {number} page The page in the source to retrieve all lines from.
  * @param {string} lineIndex The index of the line on the source's page.
  */
-export const getLineOnPage = async ( sourceId, page, lineIndex ) => Lines
-  .query()
-  .join( 'shabads', 'shabads.id', 'lines.shabad_id' )
-  .where( 'source_page', page )
-  .andWhere( 'shabads.source_id', sourceId )
-  .withTranslations()
-  .orderBy( 'order_id' )
+export const getLineOnPage = async (
+  sourceId,
+  page,
+  lineIndex,
+) => getLinesOnPageBase( sourceId, page )
   .offset( lineIndex )
+  .first()
+  .then( ( { id } ) => Lines.query().where( 'id', id ).withTranslations() )
   .then( ( [ { translations, ...line } ] ) => ( {
     ...line,
     translations: translations.map( ( { additionalInformation, ...translation } ) => ( {


### PR DESCRIPTION
### Summary of PR
Previously, navigation would result in adding or removing a translation, until none were left. This was due to using a join + offset, resulting in the translations being offset, instead of the lines.

### Tests for unexpected behavior
- It works

### Time spent on PR
30 mins

### Reviewers
@saihaj 